### PR TITLE
refactor: consolidate MultiProgress ownership and add session Drop impl

### DIFF
--- a/crates/empack-lib/src/application/session.rs
+++ b/crates/empack-lib/src/application/session.rs
@@ -16,6 +16,7 @@ use reqwest::Client;
 use std::collections::HashSet;
 use std::env;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 // Abstract interface for state management operations.
 // StateManager trait removed - using concrete PackStateManager type instead.
@@ -573,11 +574,8 @@ where
     C: ConfigProvider,
     I: InteractiveProvider,
 {
-    /// Owns the progress display infrastructure
-    /// TODO(lifecycle): Field is stored for ownership but never read; LiveDisplayProvider
-    /// wraps its own Arc<MultiProgress>. Consider removing in future refactor.
-    #[allow(dead_code)]
-    multi_progress: MultiProgress,
+    /// Shared progress display infrastructure (also held by display_provider)
+    multi_progress: Arc<MultiProgress>,
     /// Display provider for this session
     display_provider: LiveDisplayProvider,
     /// Filesystem operations provider
@@ -614,8 +612,8 @@ impl
             }
         }
 
-        let multi_progress = MultiProgress::new();
-        let display_provider = LiveDisplayProvider::new_with_multi_progress(&multi_progress);
+        let multi_progress = Arc::new(MultiProgress::new());
+        let display_provider = LiveDisplayProvider::new_with_arc(multi_progress.clone());
 
         Self {
             multi_progress,
@@ -646,8 +644,8 @@ where
         config_provider: C,
         interactive_provider: I,
     ) -> Self {
-        let multi_progress = MultiProgress::new();
-        let display_provider = LiveDisplayProvider::new_with_multi_progress(&multi_progress);
+        let multi_progress = Arc::new(MultiProgress::new());
+        let display_provider = LiveDisplayProvider::new_with_arc(multi_progress.clone());
 
         Self {
             multi_progress,
@@ -733,5 +731,22 @@ where
             None => self.filesystem().current_dir()?,
         };
         Ok(PackStateManager::new(workdir, self.filesystem()))
+    }
+}
+
+impl<F, N, P, C, I> Drop for CommandSession<F, N, P, C, I>
+where
+    F: FileSystemProvider,
+    N: NetworkProvider,
+    P: ProcessProvider,
+    C: ConfigProvider,
+    I: InteractiveProvider,
+{
+    fn drop(&mut self) {
+        // Ordered teardown:
+        // 1. Clear any lingering progress bars from the shared MultiProgress
+        let _ = self.multi_progress.clear();
+        // 2. Restore cursor visibility (defense-in-depth, complements panic hook + signal handler)
+        crate::terminal::cursor::force_show_cursor();
     }
 }

--- a/crates/empack-lib/src/application/session_mocks.rs
+++ b/crates/empack-lib/src/application/session_mocks.rs
@@ -969,7 +969,7 @@ impl InteractiveProvider for MockInteractiveProvider {
 
 /// Mock command session for testing
 pub struct MockCommandSession {
-    pub multi_progress: MultiProgress,
+    pub multi_progress: Arc<MultiProgress>,
     pub display_provider: LiveDisplayProvider,
     pub filesystem_provider: MockFileSystemProvider,
     pub network_provider: MockNetworkProvider,
@@ -988,8 +988,8 @@ impl MockCommandSession {
             .expect("Failed to detect terminal capabilities for testing");
         Display::init_or_get(capabilities);
 
-        let multi_progress = MultiProgress::new();
-        let display_provider = LiveDisplayProvider::new_with_multi_progress(&multi_progress);
+        let multi_progress = Arc::new(MultiProgress::new());
+        let display_provider = LiveDisplayProvider::new_with_arc(multi_progress.clone());
 
         let filesystem_provider = MockFileSystemProvider::new();
         let packwiz_provider = MockPackwizOps::new()

--- a/crates/empack-lib/src/display/live.rs
+++ b/crates/empack-lib/src/display/live.rs
@@ -21,10 +21,8 @@ impl LiveDisplayProvider {
         }
     }
 
-    pub fn new_with_multi_progress(multi_progress: &MultiProgress) -> Self {
-        Self {
-            multi_progress: Arc::new(multi_progress.clone()),
-        }
+    pub fn new_with_arc(multi_progress: Arc<MultiProgress>) -> Self {
+        Self { multi_progress }
     }
 }
 


### PR DESCRIPTION
## Summary

Consolidates `MultiProgress` ownership into a shared `Arc<MultiProgress>` and adds a `Drop` impl to `CommandSession` for ordered teardown.

- **MultiProgress consolidation:** Previously `CommandSession` held a bare `MultiProgress` (marked `#[allow(dead_code)]`) and passed it to `LiveDisplayProvider`, which cloned it into a separate `Arc`. Now both hold the same `Arc<MultiProgress>`, making shared ownership explicit. Removes unused `LiveDisplayProvider::new_with_multi_progress()`, replaced by `new_with_arc()`.

- **Session Drop impl:** `CommandSession` now implements `Drop` with ordered teardown: (1) clear any lingering progress bars via the shared `MultiProgress`, (2) restore cursor visibility via `force_show_cursor()`. The Drop is infallible and complements the existing panic hook and signal handler paths as defense-in-depth.

## Changes

| File | Change |
|------|--------|
| `session.rs` | `multi_progress` field: `MultiProgress` → `Arc<MultiProgress>`, removed `#[allow(dead_code)]`, added `Drop` impl |
| `live.rs` | Replaced `new_with_multi_progress(&MultiProgress)` with `new_with_arc(Arc<MultiProgress>)` |
| `session_mocks.rs` | Updated `MockCommandSession` to use `Arc<MultiProgress>` |

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [x] `cargo nextest run -p empack-lib --features test-utils` — 329 passed
- [x] `cargo nextest run -p empack-tests` — 46 passed
- [x] No remaining `#[allow(dead_code)]` on `multi_progress` field
- [x] No remaining callers of `new_with_multi_progress`