### PR TITLE
fix: platform-aware timeout message, deduplicate transition validation, add #[must_use] to guard

### DIFF
--- a/crates/empack-lib/src/application/session.rs
+++ b/crates/empack-lib/src/application/session.rs
@@ -426,10 +426,15 @@ impl ProcessProvider for LiveProcessProvider {
                     // The background thread will clean up when the process exits or parent dies.
                     let _ = child_id;
                 }
+                #[cfg(unix)]
+                let kill_status = "process killed";
+                #[cfg(windows)]
+                let kill_status = "process may still be running";
                 anyhow::bail!(
-                    "Command '{}' timed out after {} seconds (process killed)",
+                    "Command '{}' timed out after {} seconds ({})",
                     cmd_name,
-                    PROCESS_TIMEOUT.as_secs()
+                    PROCESS_TIMEOUT.as_secs(),
+                    kill_status
                 )
             }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {

--- a/crates/empack-lib/src/empack/state.rs
+++ b/crates/empack-lib/src/empack/state.rs
@@ -194,6 +194,7 @@ fn remove_state_marker<P: crate::application::session::FileSystemProvider + ?Siz
 /// Call `complete()` after successful operations to remove the marker explicitly.
 /// If the guard is dropped without calling `complete()` (e.g., due to error or panic),
 /// it performs best-effort marker removal to avoid stuck Interrupted state.
+#[must_use = "dropping the guard immediately removes the marker, leaving the pipeline unguarded"]
 pub(crate) struct StateMarkerGuard<'a, P: crate::application::session::FileSystemProvider + ?Sized> {
     provider: &'a P,
     workdir: PathBuf,
@@ -634,14 +635,10 @@ impl<'a, P: crate::application::session::FileSystemProvider + ?Sized> PackStateM
         execute_transition(self.provider, process, packwiz, &self.workdir, transition).await
     }
 
-    /// Begin a state transition (for BuildOrchestrator to use)
-    pub fn begin_state_transition(
-        &self,
-        transition: StateTransition<'_>,
-    ) -> Result<(), StateError> {
+    /// Validate a transition and return the state label string for marker files.
+    fn validate_transition(&self, transition: &StateTransition<'_>) -> Result<&'static str, StateError> {
         let current = self.discover_state()?;
 
-        // Validate that the transition is allowed
         match transition {
             StateTransition::Building => {
                 if !matches!(current, PackState::Configured | PackState::Built)
@@ -652,7 +649,7 @@ impl<'a, P: crate::application::session::FileSystemProvider + ?Sized> PackStateM
                         to: PackState::Building,
                     });
                 }
-                write_state_marker(self.provider, &self.workdir, "building")?;
+                Ok("building")
             }
             StateTransition::Cleaning => {
                 if current != PackState::Built {
@@ -661,18 +658,25 @@ impl<'a, P: crate::application::session::FileSystemProvider + ?Sized> PackStateM
                         to: PackState::Cleaning,
                     });
                 }
-                write_state_marker(self.provider, &self.workdir, "cleaning")?;
+                Ok("cleaning")
             }
             _ => {
-                return Err(StateError::ConfigError {
+                Err(StateError::ConfigError {
                     reason:
-                        "begin_state_transition only supports Building and Cleaning transitions"
+                        "Only Building and Cleaning transitions are supported"
                             .to_string(),
-                });
+                })
             }
         }
+    }
 
-        Ok(())
+    /// Begin a state transition (for BuildOrchestrator to use)
+    pub fn begin_state_transition(
+        &self,
+        transition: StateTransition<'_>,
+    ) -> Result<(), StateError> {
+        let state_label = self.validate_transition(&transition)?;
+        write_state_marker(self.provider, &self.workdir, state_label)
     }
 
     /// Complete a state transition (for BuildOrchestrator to use)
@@ -686,38 +690,7 @@ impl<'a, P: crate::application::session::FileSystemProvider + ?Sized> PackStateM
         &self,
         transition: StateTransition<'_>,
     ) -> Result<StateMarkerGuard<'_, P>, StateError> {
-        let current = self.discover_state()?;
-
-        let state_label = match transition {
-            StateTransition::Building => {
-                if !matches!(current, PackState::Configured | PackState::Built)
-                    || !validate_state_layout(self.provider, &self.workdir, &current)
-                {
-                    return Err(StateError::InvalidTransition {
-                        from: current,
-                        to: PackState::Building,
-                    });
-                }
-                "building"
-            }
-            StateTransition::Cleaning => {
-                if current != PackState::Built {
-                    return Err(StateError::InvalidTransition {
-                        from: current,
-                        to: PackState::Cleaning,
-                    });
-                }
-                "cleaning"
-            }
-            _ => {
-                return Err(StateError::ConfigError {
-                    reason:
-                        "guarded_transition only supports Building and Cleaning transitions"
-                            .to_string(),
-                });
-            }
-        };
-
+        let state_label = self.validate_transition(&transition)?;
         StateMarkerGuard::new(self.provider, self.workdir.clone(), state_label)
     }
 


### PR DESCRIPTION
## Summary

Addresses three P2 review findings from Greptile's second review round on PR #5.

- **Platform-aware timeout message:** Error message now says `(process killed)` on unix and `(process may still be running)` on Windows, matching actual behavior per platform.

- **Deduplicate transition validation:** Extracts `validate_transition()` helper used by both `begin_state_transition` and `guarded_transition`. Eliminates copy-pasted validation logic that could diverge when adding new transition types. Net -22 lines.

- **`#[must_use]` on `StateMarkerGuard`:** Accidentally discarding the guard (which immediately removes the marker via Drop) now produces a compiler warning with an explanation of why it's wrong.

## Changes

| File | Change |
|------|--------|
| `session.rs` | `#[cfg(unix/windows)]` on `kill_status` string in timeout error |
| `state.rs` | New `validate_transition()` helper, `#[must_use]` on `StateMarkerGuard` |

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [x] `cargo nextest run -p empack-lib --features test-utils` — 329 passed
- [x] `cargo nextest run -p empack-tests` — 46 passed