### PR TITLE
fix: init without positional name now creates subdirectory

### DIFF
--- a/crates/empack-lib/src/application/commands.rs
+++ b/crates/empack-lib/src/application/commands.rs
@@ -213,7 +213,7 @@ async fn handle_init(
     // Handle directory creation case: `empack init <name>` where <name> is a directory
     // Precedence: positional arg > --name flag
     let name = positional_name.or(cli_pack_name.clone());
-    let (target_dir, initial_name, needs_mkdir) = if let Some(name) = name {
+    let (mut target_dir, initial_name, mut needs_mkdir) = if let Some(name) = name {
         let potential_dir = session
             .config()
             .app_config()
@@ -235,6 +235,11 @@ async fn handle_init(
         (workdir, None, false)
     };
 
+    // Track whether the target directory already contains a project.
+    // When true and initial_name is None, the user wants in-place reinit,
+    // so we should NOT retarget to a subdirectory after the interactive prompt.
+    let mut existing_project_in_cwd = false;
+
     // Check state only if the directory already exists
     if !needs_mkdir {
         let manager =
@@ -242,6 +247,7 @@ async fn handle_init(
 
         let mut current_state = manager.discover_state()?;
         if current_state != PackState::Uninitialized {
+            existing_project_in_cwd = initial_name.is_none();
             if !force {
                 session
                     .display()
@@ -282,13 +288,15 @@ async fn handle_init(
         .section("Initializing modpack project");
 
     // Get default name from directory or command line
-    let default_name = initial_name.unwrap_or_else(|| {
-        target_dir
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("Pack")
-            .to_string()
-    });
+    let default_name = initial_name
+        .as_deref()
+        .unwrap_or(
+            target_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("Pack"),
+        )
+        .to_string();
 
     // Interactive prompt for modpack configuration (or use CLI flag)
     let modpack_name = if let Some(name) = cli_pack_name.clone() {
@@ -302,6 +310,56 @@ async fn handle_init(
             .interactive()
             .text_input("Modpack name", default_name)?
     };
+
+    // When no name was provided via CLI and the cwd is not already a project,
+    // the interactively-entered name determines the target subdirectory
+    // (like `empack init <name>` would).
+    if initial_name.is_none() && !existing_project_in_cwd {
+        let new_target = target_dir.join(&modpack_name);
+        needs_mkdir = !session.filesystem().exists(&new_target);
+
+        // If the new target exists and already has a modpack, check state
+        if !needs_mkdir {
+            let new_manager =
+                crate::empack::state::PackStateManager::new(new_target.clone(), session.filesystem());
+            let new_state = new_manager.discover_state()?;
+            if new_state != PackState::Uninitialized {
+                if !force {
+                    session.display().status().error(
+                        "Directory already contains a modpack project",
+                        &new_target.display().to_string(),
+                    );
+                    session
+                        .display()
+                        .status()
+                        .subtle("   Use --force to overwrite existing files");
+                    return Ok(());
+                }
+                // Force path: clean existing state
+                session
+                    .display()
+                    .status()
+                    .checking("Resetting existing project state for --force init");
+                let mut current_state = new_state;
+                while current_state != PackState::Uninitialized {
+                    let result = new_manager
+                        .execute_transition(
+                            session.process(),
+                            &*session.packwiz(),
+                            StateTransition::Clean,
+                        )
+                        .await
+                        .context("Failed to reset existing project before initialization")?;
+                    for w in &result.warnings {
+                        session.display().status().warning(w);
+                    }
+                    current_state = result.state;
+                }
+            }
+        }
+
+        target_dir = new_target;
+    }
 
     // Try to get git user.name as smart default.
     // Use parent dir (or target_dir itself) as cwd because target_dir

--- a/crates/empack-tests/tests/build_with_missing_template.rs
+++ b/crates/empack-tests/tests/build_with_missing_template.rs
@@ -53,13 +53,21 @@ async fn test_build_with_missing_template() -> Result<()> {
     )
     .await?;
 
+    // When no name is provided via CLI, the interactively-entered name
+    // (defaulting to the directory name) becomes the target subdirectory.
+    let dir_name = workdir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("Pack");
+    let project_dir = workdir.join(dir_name);
+
     // First, verify the project was initialized
     assert!(
-        workdir.join("empack.yml").exists(),
+        project_dir.join("empack.yml").exists(),
         "empack.yml should exist"
     );
     assert!(
-        workdir.join("pack").exists(),
+        project_dir.join("pack").exists(),
         "pack/ directory should exist"
     );
 
@@ -71,6 +79,9 @@ async fn test_build_with_missing_template() -> Result<()> {
         jar_cache.join("packwiz-installer-bootstrap.jar"),
         "mock jar content",
     )?;
+
+    // Change to project directory since build needs to find the project
+    std::env::set_current_dir(&project_dir)?;
 
     // Attempt a build - this should detect missing templates gracefully
     // Note: In the hermetic environment, the build might fail for other reasons
@@ -158,6 +169,14 @@ async fn test_build_template_error_specificity() -> Result<()> {
         &session,
     )
     .await?;
+
+    // When no name is provided via CLI, init creates a subdirectory
+    let dir_name = workdir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("Pack");
+    let project_dir = workdir.join(dir_name);
+    std::env::set_current_dir(&project_dir)?;
 
     // Try building with a target that might have template dependencies
     let build_result = execute_command_with_session(

--- a/crates/empack-tests/tests/init_workflows.rs
+++ b/crates/empack-tests/tests/init_workflows.rs
@@ -75,15 +75,23 @@ async fn test_init_zero_config() -> Result<()> {
     // Verify init succeeded
     assert!(result.is_ok(), "Init command failed: {:?}", result);
 
-    // Verify empack.yml was created
-    let empack_yml_path = workdir.join("empack.yml");
+    // When no name is provided via CLI, the interactively-entered name
+    // (defaulting to the directory name) becomes the target subdirectory.
+    let dir_name = workdir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("Pack");
+    let project_dir = workdir.join(dir_name);
+
+    // Verify empack.yml was created inside the subdirectory
+    let empack_yml_path = project_dir.join("empack.yml");
     assert!(
         empack_yml_path.exists(),
-        "empack.yml should be created in work directory"
+        "empack.yml should be created in subdirectory named after the modpack"
     );
 
-    // Verify pack/ directory was created
-    let pack_dir = workdir.join("pack");
+    // Verify pack/ directory was created inside the subdirectory
+    let pack_dir = project_dir.join("pack");
     assert!(pack_dir.exists(), "pack/ directory should be created");
 
     // Verify packwiz init was called


### PR DESCRIPTION
## Summary
- `empack init` (no positional name) was writing files directly into `cwd` instead of creating a subdirectory named after the interactively-entered modpack name
- Root cause: `target_dir` was bound to `cwd` before the interactive prompt, and never updated after the user typed a name
- Adds `existing_project_in_cwd` guard so `--force` reinit in an existing project directory still works in-place

## Changes
- `commands.rs`: Retarget `target_dir` to `cwd.join(&modpack_name)` after interactive prompt when no CLI name was provided
- `init_workflows.rs`: Update test assertions to expect subdirectory
- `build_with_missing_template.rs`: Update test assertions to expect subdirectory

## Test plan
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- [x] `cargo nextest run -p empack-lib --features test-utils` 325 pass, 15 skipped
- [x] `cargo nextest run -p empack-tests` 46 pass