### PR TITLE
fix: move template scaffolding after state transition in init

### DIFF
--- a/crates/empack-lib/src/application/commands.rs
+++ b/crates/empack-lib/src/application/commands.rs
@@ -778,7 +778,20 @@ async fn execute_init_phase(
         .filesystem()
         .write_file(&target_dir.join("empack.yml"), &empack_yml_content)?;
 
-    // Scaffold project structure and templates (non-fatal: warn on failure)
+    let transition_result = manager
+        .execute_transition(
+            session.process(),
+            &*session.packwiz(),
+            StateTransition::Initialize(*config),
+        )
+        .await
+        .context("Failed to initialize modpack project")?;
+    for w in &transition_result.warnings {
+        session.display().status().warning(w);
+    }
+
+    // Scaffold project structure and templates after state transition succeeds.
+    // Must run AFTER transition to avoid discover_state seeing dist/ as Built.
     let mut installer = crate::empack::templates::TemplateInstaller::new(session.filesystem());
     installer.configure(
         config.name,
@@ -796,18 +809,6 @@ async fn execute_init_phase(
             .display()
             .status()
             .warning(&format!("Template scaffolding incomplete: {}", e));
-    }
-
-    let transition_result = manager
-        .execute_transition(
-            session.process(),
-            &*session.packwiz(),
-            StateTransition::Initialize(*config),
-        )
-        .await
-        .context("Failed to initialize modpack project")?;
-    for w in &transition_result.warnings {
-        session.display().status().warning(w);
     }
 
     match transition_result.state {


### PR DESCRIPTION
## Summary

Template installer creates dist/ directories with .gitkeep files during init. has_build_artifacts detects these as Built state, causing discover_state to return Built before the Initialize transition runs. The transition Built -> Configured (Initialize) is rejected.

Fix: move install_all after execute_transition(Initialize) succeeds.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run -p empack-lib --features test-utils` (583 pass)
- [x] `cargo nextest run -p empack-tests` (69 pass)