### PR TITLE
fix: init in-place when name matches current directory

### DIFF
--- a/crates/empack-lib/src/application/commands.rs
+++ b/crates/empack-lib/src/application/commands.rs
@@ -333,58 +333,63 @@ async fn handle_init(
     };
 
     // When no name was provided via CLI and the cwd is not already a project,
-    // the interactively-entered name determines the target subdirectory
-    // (like `empack init <name>` would).
+    // decide whether to init in-place or create a subdirectory.
+    // If the entered name matches the current directory name, init in place.
     if initial_name.is_none() && !existing_project_in_cwd {
-        let new_target = target_dir.join(&modpack_name);
-        needs_mkdir = !session.filesystem().exists(&new_target);
+        let dir_name = target_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
 
-        // If the new target exists and already has a modpack, check state
-        if !needs_mkdir {
-            let new_manager = crate::empack::state::PackStateManager::new(
-                new_target.clone(),
-                session.filesystem(),
-            );
-            let new_state = new_manager.discover_state()?;
-            if new_state != PackState::Uninitialized {
-                if !force {
-                    session.display().status().error(
-                        "Directory already contains a modpack project",
-                        &new_target.display().to_string(),
-                    );
+        if modpack_name != dir_name {
+            let new_target = target_dir.join(&modpack_name);
+            needs_mkdir = !session.filesystem().exists(&new_target);
+
+            if !needs_mkdir {
+                let new_manager = crate::empack::state::PackStateManager::new(
+                    new_target.clone(),
+                    session.filesystem(),
+                );
+                let new_state = new_manager.discover_state()?;
+                if new_state != PackState::Uninitialized {
+                    if !force {
+                        session.display().status().error(
+                            "Directory already contains a modpack project",
+                            &new_target.display().to_string(),
+                        );
+                        session
+                            .display()
+                            .status()
+                            .subtle("   Use --force to overwrite existing files");
+                        return Err(anyhow::anyhow!(
+                            "Directory '{}' already contains a modpack project. Use --force to overwrite existing files.",
+                            new_target.display()
+                        ));
+                    }
                     session
                         .display()
                         .status()
-                        .subtle("   Use --force to overwrite existing files");
-                    return Err(anyhow::anyhow!(
-                        "Directory '{}' already contains a modpack project. Use --force to overwrite existing files.",
-                        new_target.display()
-                    ));
-                }
-                // Force path: clean existing state
-                session
-                    .display()
-                    .status()
-                    .checking("Resetting existing project state for --force init");
-                let mut current_state = new_state;
-                while current_state != PackState::Uninitialized {
-                    let result = new_manager
-                        .execute_transition(
-                            session.process(),
-                            &*session.packwiz(),
-                            StateTransition::Clean,
-                        )
-                        .await
-                        .context("Failed to reset existing project before initialization")?;
-                    for w in &result.warnings {
-                        session.display().status().warning(w);
+                        .checking("Resetting existing project state for --force init");
+                    let mut current_state = new_state;
+                    while current_state != PackState::Uninitialized {
+                        let result = new_manager
+                            .execute_transition(
+                                session.process(),
+                                &*session.packwiz(),
+                                StateTransition::Clean,
+                            )
+                            .await
+                            .context("Failed to reset existing project before initialization")?;
+                        for w in &result.warnings {
+                            session.display().status().warning(w);
+                        }
+                        current_state = result.state;
                     }
-                    current_state = result.state;
                 }
             }
-        }
 
-        target_dir = new_target;
+            target_dir = new_target;
+        }
     }
 
     // Try to get git user.name as smart default.

--- a/crates/empack-tests/tests/build_with_missing_template.rs
+++ b/crates/empack-tests/tests/build_with_missing_template.rs
@@ -34,18 +34,13 @@ async fn test_build_with_missing_template() -> Result<()> {
     .await?;
 
     let workdir = session.filesystem().current_dir()?;
-    let dir_name = workdir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("Pack");
-    let project_dir = workdir.join(dir_name);
 
     assert!(
-        session.filesystem().exists(&project_dir.join("empack.yml")),
+        session.filesystem().exists(&workdir.join("empack.yml")),
         "empack.yml should exist"
     );
     assert!(
-        session.filesystem().exists(&project_dir.join("pack")),
+        session.filesystem().exists(&workdir.join("pack")),
         "pack/ directory should exist"
     );
 

--- a/crates/empack-tests/tests/init_workflows.rs
+++ b/crates/empack-tests/tests/init_workflows.rs
@@ -46,26 +46,22 @@ async fn test_init_zero_config() -> Result<()> {
 
     assert!(result.is_ok(), "Init command failed: {:?}", result);
 
-    let dir_name = workdir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("Pack");
-    let project_dir = workdir.join(dir_name);
-
+    // With --yes and no name, the default name matches the directory name,
+    // so init should happen in-place (not create a nested subdirectory).
     assert!(
-        session.filesystem().exists(&project_dir.join("empack.yml")),
-        "empack.yml should be created in subdirectory named after the modpack"
+        session.filesystem().exists(&workdir.join("empack.yml")),
+        "empack.yml should be created in the current directory when name matches dir name"
     );
 
-    let pack_dir = project_dir.join("pack");
     assert!(
-        session.filesystem().exists(&pack_dir),
+        session.filesystem().exists(&workdir.join("pack")),
         "pack/ directory should be created"
     );
 
-    let pack_toml_path = pack_dir.join("pack.toml");
     assert!(
-        session.filesystem().exists(&pack_toml_path),
+        session
+            .filesystem()
+            .exists(&workdir.join("pack").join("pack.toml")),
         "pack.toml should exist after packwiz init"
     );
 
@@ -396,6 +392,133 @@ async fn test_init_scaffolds_template_files() -> Result<()> {
             .filesystem()
             .exists(&project_dir.join(".github/workflows/release.yml")),
         ".github/workflows/release.yml should be created after init"
+    );
+
+    Ok(())
+}
+
+/// Test: empack init in a directory whose name matches the interactively entered
+/// modpack name should init in-place instead of creating a subdirectory.
+/// Uses --yes which returns the default name (dir basename) from the prompt.
+#[tokio::test]
+async fn test_init_in_matching_named_directory() -> Result<()> {
+    let session = MockSessionBuilder::new().with_yes_flag().build();
+
+    Display::init_or_get(TerminalCapabilities::minimal());
+
+    let workdir = session.filesystem().current_dir()?;
+    let dir_name = workdir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap()
+        .to_string();
+
+    // No positional name, no --name flag. --yes causes the interactive prompt
+    // to return the default (directory basename). Since that matches the dir name,
+    // init should happen in-place.
+    let result = execute_command_with_session(
+        Commands::Init {
+            name: None,
+            pack_name: None,
+            force: false,
+            modloader: Some("fabric".to_string()),
+            mc_version: Some("1.21.4".to_string()),
+            author: Some("Test".to_string()),
+            loader_version: None,
+            pack_version: None,
+        },
+        &session,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Init in matching dir failed: {:?}",
+        result.err()
+    );
+
+    assert!(
+        session.filesystem().exists(&workdir.join("empack.yml")),
+        "empack.yml should be in the current directory when name matches dir name"
+    );
+    assert!(
+        !session
+            .filesystem()
+            .exists(&workdir.join(&dir_name).join("empack.yml")),
+        "empack.yml should NOT be in a nested subdirectory when name matches"
+    );
+
+    Ok(())
+}
+
+/// Test: empack init in a directory whose name does NOT match creates subdirectory.
+#[tokio::test]
+async fn test_init_in_nonmatching_directory_creates_subdir() -> Result<()> {
+    let session = MockSessionBuilder::new().with_yes_flag().build();
+
+    Display::init_or_get(TerminalCapabilities::minimal());
+
+    let workdir = session.filesystem().current_dir()?;
+
+    let result = execute_command_with_session(
+        Commands::Init {
+            name: None,
+            pack_name: Some("different-name".to_string()),
+            force: false,
+            modloader: Some("fabric".to_string()),
+            mc_version: Some("1.21.4".to_string()),
+            author: Some("Test".to_string()),
+            loader_version: None,
+            pack_version: None,
+        },
+        &session,
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Init with different name failed: {:?}",
+        result.err()
+    );
+
+    let project_dir = workdir.join("different-name");
+    assert!(
+        session.filesystem().exists(&project_dir.join("empack.yml")),
+        "empack.yml should be in different-name/ subdirectory"
+    );
+
+    Ok(())
+}
+
+/// Test: empack init . uses current directory in-place.
+#[tokio::test]
+async fn test_init_dot_uses_current_directory() -> Result<()> {
+    let session = MockSessionBuilder::new().with_yes_flag().build();
+
+    Display::init_or_get(TerminalCapabilities::minimal());
+
+    let workdir = session.filesystem().current_dir()?;
+
+    let result = execute_command_with_session(
+        Commands::Init {
+            name: Some(".".to_string()),
+            pack_name: None,
+            force: false,
+            modloader: Some("fabric".to_string()),
+            mc_version: Some("1.21.4".to_string()),
+            author: Some("Test".to_string()),
+            loader_version: None,
+            pack_version: None,
+        },
+        &session,
+    )
+    .await;
+
+    assert!(result.is_ok(), "Init with . failed: {:?}", result.err());
+
+    assert!(
+        session.filesystem().exists(&workdir.join("empack.yml")),
+        "empack.yml should be in the current directory"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

When running `empack init` without a positional name and the interactively entered (or --yes defaulted) name matches the current directory's basename, init in-place instead of creating a nested subdirectory.

Before: `cd my-pack && empack init --yes` creates `my-pack/my-pack/`
After: `cd my-pack && empack init --yes` initializes in `my-pack/`

Also supports `empack init .` for explicit in-place initialization.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run -p empack-lib --features test-utils` (583 pass)
- [x] `cargo nextest run -p empack-tests` (72 pass)
- [x] New: `test_init_in_matching_named_directory`
- [x] New: `test_init_in_nonmatching_directory_creates_subdir`
- [x] New: `test_init_dot_uses_current_directory`