### PR TITLE
refactor: separate init directory from pack name

### DIFF
--- a/crates/empack-lib/src/application/cli.rs
+++ b/crates/empack-lib/src/application/cli.rs
@@ -47,8 +47,8 @@ pub enum Commands {
 
     /// Initialize modpack development environment
     Init {
-        /// Modpack name
-        #[arg(help = "Name of the modpack to initialize")]
+        /// Target directory for the modpack project
+        #[arg(help = "Directory for the modpack project (created if needed)")]
         name: Option<String>,
 
         /// Force overwrite existing files
@@ -81,12 +81,12 @@ pub enum Commands {
         )]
         author: Option<String>,
 
-        /// Modpack name (same as positional argument)
+        /// Modpack display name
         #[arg(
             long,
             short = 'n',
             env = "EMPACK_NAME",
-            help = "Modpack name (skips interactive prompt)"
+            help = "Modpack display name (default: directory basename)"
         )]
         pack_name: Option<String>,
 

--- a/crates/empack-lib/src/application/commands.rs
+++ b/crates/empack-lib/src/application/commands.rs
@@ -227,35 +227,21 @@ async fn handle_init(
         ));
     }
 
-    // Handle directory creation case: `empack init <name>` where <name> is a directory
-    // Precedence: positional arg > --name flag
-    let name = positional_name.or(cli_pack_name.clone());
-    let (mut target_dir, initial_name, mut needs_mkdir) = if let Some(name) = name {
-        let potential_dir = session
-            .config()
-            .app_config()
-            .workdir
-            .as_ref()
-            .unwrap_or(&session.filesystem().current_dir()?)
-            .join(&name);
+    // Phase A: Resolve target_dir (WHERE). Only the positional arg affects directory.
+    let base_dir = session.config().app_config().workdir.clone().unwrap_or(
+        session
+            .filesystem()
+            .current_dir()
+            .context("Failed to get current directory")?,
+    );
 
-        let needs_mkdir = !session.filesystem().exists(&potential_dir);
-        (potential_dir, Some(name), needs_mkdir)
+    let (target_dir, needs_mkdir) = if let Some(ref dir_arg) = positional_name {
+        let target = base_dir.join(dir_arg);
+        let needs_mkdir = !session.filesystem().exists(&target);
+        (target, needs_mkdir)
     } else {
-        let workdir = match session.config().app_config().workdir.as_ref().cloned() {
-            Some(w) => w,
-            None => session
-                .filesystem()
-                .current_dir()
-                .context("Failed to get current directory")?,
-        };
-        (workdir, None, false)
+        (base_dir, false)
     };
-
-    // Track whether the target directory already contains a project.
-    // When true and initial_name is None, the user wants in-place reinit,
-    // so we should NOT retarget to a subdirectory after the interactive prompt.
-    let mut existing_project_in_cwd = false;
 
     // Check state only if the directory already exists
     if !needs_mkdir {
@@ -264,7 +250,6 @@ async fn handle_init(
 
         let mut current_state = manager.discover_state()?;
         if current_state != PackState::Uninitialized {
-            existing_project_in_cwd = initial_name.is_none();
             if !force {
                 session
                     .display()
@@ -306,86 +291,25 @@ async fn handle_init(
         .status()
         .section("Initializing modpack project");
 
-    // Get default name from directory or command line
-    let default_name = initial_name
-        .as_deref()
-        .unwrap_or(
-            target_dir
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("Pack"),
-        )
+    // Phase B: Resolve pack_name (WHAT). Never affects directory.
+    let dir_basename = target_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("Pack")
         .to_string();
 
-    // Display name precedence: --name flag > positional arg (initial_name).
-    // This differs from the *directory* precedence at line 232 (positional > --name)
-    // because --name is the user's explicit display-name preference.
-    let modpack_name = if let Some(name) = cli_pack_name.clone().or(initial_name.clone()) {
+    let modpack_name = if let Some(name) = cli_pack_name.clone() {
+        // --name flag is the explicit display name; highest priority
         session
             .display()
             .status()
             .info(&format!("Using name: {}", name));
         name
     } else {
-        session
-            .interactive()
-            .text_input("Modpack name", default_name)?
+        // Default: positional arg if given, else directory basename
+        let default = positional_name.clone().unwrap_or(dir_basename);
+        session.interactive().text_input("Modpack name", default)?
     };
-
-    // When no name was provided via CLI and the cwd is not already a project,
-    // the interactively-entered name determines the target subdirectory
-    // (like `empack init <name>` would).
-    if initial_name.is_none() && !existing_project_in_cwd {
-        let new_target = target_dir.join(&modpack_name);
-        needs_mkdir = !session.filesystem().exists(&new_target);
-
-        // If the new target exists and already has a modpack, check state
-        if !needs_mkdir {
-            let new_manager = crate::empack::state::PackStateManager::new(
-                new_target.clone(),
-                session.filesystem(),
-            );
-            let new_state = new_manager.discover_state()?;
-            if new_state != PackState::Uninitialized {
-                if !force {
-                    session.display().status().error(
-                        "Directory already contains a modpack project",
-                        &new_target.display().to_string(),
-                    );
-                    session
-                        .display()
-                        .status()
-                        .subtle("   Use --force to overwrite existing files");
-                    return Err(anyhow::anyhow!(
-                        "Directory '{}' already contains a modpack project. Use --force to overwrite existing files.",
-                        new_target.display()
-                    ));
-                }
-                // Force path: clean existing state
-                session
-                    .display()
-                    .status()
-                    .checking("Resetting existing project state for --force init");
-                let mut current_state = new_state;
-                while current_state != PackState::Uninitialized {
-                    let result = new_manager
-                        .execute_transition(
-                            session.process(),
-                            &*session.packwiz(),
-                            StateTransition::Clean,
-                        )
-                        .await
-                        .context("Failed to reset existing project before initialization")?;
-                    for w in &result.warnings {
-                        session.display().status().warning(w);
-                    }
-                    current_state = result.state;
-                }
-            }
-        }
-
-        target_dir = new_target;
-    }
 
     // Try to get git user.name as smart default.
     // Use parent dir (or target_dir itself) as cwd because target_dir

--- a/crates/empack-lib/src/application/commands.test.rs
+++ b/crates/empack-lib/src/application/commands.test.rs
@@ -582,6 +582,144 @@ mod handle_init_tests {
             "pre-existing directory should NOT be removed on force init failure"
         );
     }
+
+    #[tokio::test]
+    async fn it_separates_directory_from_name() {
+        let workdir = mock_root().join("dir-name-split");
+        let target_dir = workdir.join("my-dir");
+        let session = MockCommandSession::new()
+            .with_filesystem(MockFileSystemProvider::new().with_current_dir(workdir))
+            .with_interactive(MockInteractiveProvider::new().with_yes_mode(true));
+
+        let result = handle_init(
+            &session,
+            Some("my-dir".to_string()),
+            Some("My Display Name".to_string()),
+            false,
+            Some("fabric".to_string()),
+            Some("1.21.1".to_string()),
+            Some("Test Author".to_string()),
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(session.filesystem().is_directory(&target_dir));
+
+        let empack_yml = session
+            .filesystem()
+            .read_to_string(&target_dir.join("empack.yml"))
+            .unwrap();
+        assert!(
+            empack_yml.contains("name: My Display Name"),
+            "empack.yml should use --name flag for display name, not directory name: {}",
+            empack_yml
+        );
+    }
+
+    #[tokio::test]
+    async fn it_does_not_create_subdir_from_interactive_name() {
+        let workdir = mock_root().join("no-subdir-from-interactive");
+        let session = MockCommandSession::new()
+            .with_filesystem(MockFileSystemProvider::new().with_current_dir(workdir.clone()))
+            .with_interactive(MockInteractiveProvider::new().with_yes_mode(true));
+
+        let result = handle_init(
+            &session,
+            None,
+            None,
+            false,
+            Some("fabric".to_string()),
+            Some("1.21.1".to_string()),
+            Some("Test Author".to_string()),
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(
+            session.filesystem().exists(&workdir.join("empack.yml")),
+            "empack.yml should be in cwd, not in a subdirectory"
+        );
+    }
+
+    #[tokio::test]
+    async fn it_uses_dir_basename_as_default_name_with_yes() {
+        let workdir = mock_root().join("cool-project");
+        let session = MockCommandSession::new()
+            .with_filesystem(MockFileSystemProvider::new().with_current_dir(workdir.clone()))
+            .with_interactive(MockInteractiveProvider::new().with_yes_mode(true));
+
+        let result = handle_init(
+            &session,
+            None,
+            None,
+            false,
+            Some("fabric".to_string()),
+            Some("1.21.1".to_string()),
+            Some("Test Author".to_string()),
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+
+        let empack_yml = session
+            .filesystem()
+            .read_to_string(&workdir.join("empack.yml"))
+            .unwrap();
+        assert!(
+            empack_yml.contains("name: cool-project"),
+            "empack.yml should default name to directory basename 'cool-project': {}",
+            empack_yml
+        );
+    }
+
+    #[tokio::test]
+    async fn it_name_flag_with_spaces_does_not_create_directory() {
+        let workdir = mock_root().join("name-spaces-test");
+        let session = MockCommandSession::new()
+            .with_filesystem(MockFileSystemProvider::new().with_current_dir(workdir.clone()))
+            .with_interactive(MockInteractiveProvider::new().with_yes_mode(true));
+
+        let result = handle_init(
+            &session,
+            None,
+            Some("My Cool Pack".to_string()),
+            false,
+            Some("fabric".to_string()),
+            Some("1.21.1".to_string()),
+            Some("Test Author".to_string()),
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(
+            !session
+                .filesystem()
+                .is_directory(&workdir.join("My Cool Pack")),
+            "No 'My Cool Pack' directory should be created from --name flag"
+        );
+        assert!(
+            session.filesystem().exists(&workdir.join("empack.yml")),
+            "empack.yml should be in cwd, not in a space-named directory"
+        );
+
+        let empack_yml = session
+            .filesystem()
+            .read_to_string(&workdir.join("empack.yml"))
+            .unwrap();
+        assert!(
+            empack_yml.contains("name: My Cool Pack"),
+            "empack.yml should contain the display name from --name flag: {}",
+            empack_yml
+        );
+    }
 }
 
 // ===== VALIDATE_INIT_INPUTS UNIT TESTS =====
@@ -3118,11 +3256,11 @@ mod init_interactive_tests {
         );
     }
 
-    // I2: handle_init with a positional name must skip the interactive name
-    // prompt.
+    // I2: handle_init with a positional name uses it as the default for the
+    // interactive name prompt (the --name flag is needed to skip the prompt).
     #[tokio::test]
-    async fn test_handle_init_positional_name_skips_prompt() {
-        let workdir = mock_root().join("positional-name-skip");
+    async fn test_handle_init_positional_name_sets_prompt_default() {
+        let workdir = mock_root().join("positional-name-default");
         let session = MockCommandSession::new()
             .with_filesystem(MockFileSystemProvider::new().with_current_dir(workdir))
             .with_interactive(MockInteractiveProvider::new().with_yes_mode(true));
@@ -3140,14 +3278,21 @@ mod init_interactive_tests {
         )
         .await;
 
+        // Positional name is the default for the interactive prompt (not a skip).
+        // The --name flag is the only way to skip the name prompt entirely.
         let text_calls = session.interactive_provider.get_text_input_calls();
-        let name_prompt_fired = text_calls
+        let name_call = text_calls
             .iter()
-            .any(|(prompt, _)| prompt.contains("Modpack name") || prompt.contains("name"));
+            .find(|(prompt, _)| prompt.contains("Modpack name"));
         assert!(
-            !name_prompt_fired,
-            "Positional name 'my-pack' should skip the name prompt; text_input calls: {:?}",
+            name_call.is_some(),
+            "Positional name should be passed as default to interactive prompt; text_input calls: {:?}",
             text_calls
+        );
+        assert_eq!(
+            name_call.unwrap().1,
+            "my-pack",
+            "Positional name 'my-pack' should be the default for the name prompt"
         );
     }
 

--- a/crates/empack-tests/tests/build_with_missing_template.rs
+++ b/crates/empack-tests/tests/build_with_missing_template.rs
@@ -34,18 +34,13 @@ async fn test_build_with_missing_template() -> Result<()> {
     .await?;
 
     let workdir = session.filesystem().current_dir()?;
-    let dir_name = workdir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("Pack");
-    let project_dir = workdir.join(dir_name);
 
     assert!(
-        session.filesystem().exists(&project_dir.join("empack.yml")),
+        session.filesystem().exists(&workdir.join("empack.yml")),
         "empack.yml should exist"
     );
     assert!(
-        session.filesystem().exists(&project_dir.join("pack")),
+        session.filesystem().exists(&workdir.join("pack")),
         "pack/ directory should exist"
     );
 

--- a/crates/empack-tests/tests/init_workflows.rs
+++ b/crates/empack-tests/tests/init_workflows.rs
@@ -46,18 +46,12 @@ async fn test_init_zero_config() -> Result<()> {
 
     assert!(result.is_ok(), "Init command failed: {:?}", result);
 
-    let dir_name = workdir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("Pack");
-    let project_dir = workdir.join(dir_name);
-
     assert!(
-        session.filesystem().exists(&project_dir.join("empack.yml")),
-        "empack.yml should be created in subdirectory named after the modpack"
+        session.filesystem().exists(&workdir.join("empack.yml")),
+        "empack.yml should be created in the working directory"
     );
 
-    let pack_dir = project_dir.join("pack");
+    let pack_dir = workdir.join("pack");
     assert!(
         session.filesystem().exists(&pack_dir),
         "pack/ directory should be created"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,7 +34,7 @@ empack version
 
 ### empack init
 
-Create a new modpack project or complete a partial setup.
+Create a new modpack project. The positional argument specifies the target directory; `--pack-name` sets the display name independently.
 
 ```bash
 empack init my-pack \
@@ -45,11 +45,11 @@ empack init my-pack \
   -y
 ```
 
-Without arguments, empack prompts interactively for each field.
+Without arguments, empack initializes in the current directory and prompts for each field.
 
 | Flag | Short | Env var | Description |
 | --- | --- | --- | --- |
-| `--pack-name` | `-n` | `EMPACK_NAME` | Modpack display name |
+| `--pack-name` | `-n` | `EMPACK_NAME` | Modpack display name (default: directory basename) |
 | `--modloader` | `-m` | `EMPACK_MODLOADER` | Mod loader: `neoforge`, `fabric`, `forge`, `quilt`, `none` |
 | `--mc-version` | | `EMPACK_MC_VERSION` | Minecraft version |
 | `--author` | `-A` | `EMPACK_AUTHOR` | Author name |


### PR DESCRIPTION
## Summary

Separate directory resolution from pack name resolution in handle_init.

- target_dir: positional arg or cwd (never derived from pack name)
- pack_name: --name flag or interactive prompt (never creates a directory)

## Contracts

empack init                              # dir = cwd, name = prompt(default: dir basename)
empack init my-pack                      # dir = ./my-pack/, name = prompt(default: "my-pack")
empack init . --name "Cool Pack"         # dir = cwd, name = "Cool Pack"
empack init /tmp/abc123 --name "My Pack" # dir = /tmp/abc123/, name = "My Pack"
empack init --name "My Pack" --yes       # dir = cwd, name = "My Pack"

## Test plan

- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo nextest run -p empack-lib --features test-utils
- [x] cargo nextest run -p empack-tests
- [x] 4 new unit tests for directory/name separation