### PR TITLE
fix: make clean non-destructive

### DIFF
--- a/crates/empack-lib/src/application/commands.rs
+++ b/crates/empack-lib/src/application/commands.rs
@@ -3318,7 +3318,9 @@ async fn handle_clean(session: &dyn Session, targets: Vec<String>) -> Result<()>
         let dist_dir = crate::empack::state::artifact_root(&manager.workdir);
         let has_dist = session.filesystem().is_directory(&dist_dir);
 
-        if current_state == PackState::Built {
+        if current_state == PackState::Built
+            || matches!(current_state, PackState::Interrupted { .. })
+        {
             let result = manager
                 .execute_transition(
                     session.process(),

--- a/crates/empack-lib/src/application/commands.rs
+++ b/crates/empack-lib/src/application/commands.rs
@@ -24,7 +24,7 @@ use crate::empack::search::SearchError;
 use crate::primitives::{BuildTarget, PackState, ProjectPlatform, ProjectType, StateTransition};
 use anyhow::Context;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::empack::config::format_empack_yml;
 use tracing::instrument;
@@ -83,6 +83,69 @@ pub async fn execute_command_with_session(command: Commands, session: &dyn Sessi
         Commands::Clean { targets } => handle_clean(session, targets).await,
         Commands::Sync {} => handle_sync(session).await,
     }
+}
+
+fn report_incomplete_project(session: &dyn Session, action: &str) -> Result<()> {
+    session
+        .display()
+        .status()
+        .error("Project initialization is incomplete", "");
+    session.display().status().subtle(&format!(
+        "   Re-run 'empack init --force' to restore empack.yml and pack/ metadata before {action}",
+    ));
+    Err(anyhow::anyhow!("Project initialization is incomplete"))
+}
+
+fn ensure_configured_project(
+    session: &dyn Session,
+    workdir: &Path,
+    current_state: PackState,
+    action: &str,
+) -> Result<()> {
+    let layout = crate::empack::state::probe_project_layout(session.filesystem(), workdir);
+
+    if current_state != PackState::Uninitialized && !layout.is_configured() {
+        return report_incomplete_project(session, action);
+    }
+
+    if current_state == PackState::Uninitialized {
+        if layout.is_partial_configuration() {
+            return report_incomplete_project(session, action);
+        }
+
+        session
+            .display()
+            .status()
+            .error("Not in a modpack directory", "");
+        session
+            .display()
+            .status()
+            .subtle("   Run 'empack init' to set up a modpack project");
+        return Err(anyhow::anyhow!("Not in a modpack directory"));
+    }
+
+    Ok(())
+}
+
+fn report_incomplete_existing_project(session: &dyn Session) -> Result<()> {
+    session
+        .display()
+        .status()
+        .error("Directory contains incomplete empack project metadata", "");
+    session.display().status().subtle(
+        "   Use --force to overwrite existing files, or restore the missing empack.yml / pack metadata first",
+    );
+    Err(anyhow::anyhow!(
+        "Directory contains incomplete empack project metadata. Use --force to overwrite existing files, or restore the missing empack.yml / pack metadata first."
+    ))
+}
+
+fn reset_project_for_force_init(session: &dyn Session, workdir: &Path) -> Result<()> {
+    crate::empack::state::reset_project_for_init(session.filesystem(), workdir)
+        .context("Failed to reset existing project before initialization")?;
+    crate::empack::restricted_build::clear_pending_build(session.filesystem(), workdir)
+        .context("Failed to clear pending restricted build state before initialization")?;
+    Ok(())
 }
 
 async fn handle_requirements(session: &dyn Session) -> Result<()> {
@@ -208,41 +271,35 @@ async fn handle_init(session: &dyn Session, args: &InitArgs) -> Result<()> {
         let manager =
             crate::empack::state::PackStateManager::new(target_dir.clone(), session.filesystem());
 
-        let mut current_state = manager.discover_state()?;
-        if current_state != PackState::Uninitialized {
-            if !args.force {
-                session
-                    .display()
-                    .status()
-                    .error("Directory already contains a modpack project", "");
-                session
-                    .display()
-                    .status()
-                    .subtle("   Use --force to overwrite existing files");
-                return Err(anyhow::anyhow!(
-                    "Directory already contains a modpack project. Use --force to overwrite existing files."
-                ));
-            }
+        let current_state = manager.discover_state()?;
+        let layout = crate::empack::state::probe_project_layout(session.filesystem(), &target_dir);
 
+        if layout.is_partial_configuration() && !args.force {
+            return report_incomplete_existing_project(session);
+        }
+
+        if current_state != PackState::Uninitialized && !args.force {
+            session
+                .display()
+                .status()
+                .error("Directory already contains a modpack project", "");
+            session
+                .display()
+                .status()
+                .subtle("   Use --force to overwrite existing files");
+            return Err(anyhow::anyhow!(
+                "Directory already contains a modpack project. Use --force to overwrite existing files."
+            ));
+        }
+
+        if args.force
+            && (current_state != PackState::Uninitialized || layout.is_partial_configuration())
+        {
             session
                 .display()
                 .status()
                 .checking("Resetting existing project state for --force init");
-
-            while current_state != PackState::Uninitialized {
-                let result = manager
-                    .execute_transition(
-                        session.process(),
-                        &*session.packwiz(),
-                        StateTransition::Clean,
-                    )
-                    .await
-                    .context("Failed to reset existing project before initialization")?;
-                for w in &result.warnings {
-                    session.display().status().warning(w);
-                }
-                current_state = result.state;
-            }
+            reset_project_for_force_init(session, &target_dir)?;
         }
     }
 
@@ -910,6 +967,12 @@ async fn handle_init_from_source(
         let manager =
             crate::empack::state::PackStateManager::new(target_dir.clone(), session.filesystem());
         let current_state = manager.discover_state()?;
+        let layout = crate::empack::state::probe_project_layout(session.filesystem(), &target_dir);
+
+        if layout.is_partial_configuration() && !force {
+            return report_incomplete_existing_project(session);
+        }
+
         if current_state != PackState::Uninitialized && !force {
             session
                 .display()
@@ -922,6 +985,15 @@ async fn handle_init_from_source(
             return Err(anyhow::anyhow!(
                 "Directory already contains a modpack project. Use --force to overwrite."
             ));
+        }
+
+        if force && (current_state != PackState::Uninitialized || layout.is_partial_configuration())
+        {
+            session
+                .display()
+                .status()
+                .checking("Resetting existing project state for --force init");
+            reset_project_for_force_init(session, &target_dir)?;
         }
     }
 
@@ -1440,27 +1512,12 @@ async fn handle_add(
     let current_state = manager
         .discover_state()
         .map_err(|e| anyhow::anyhow!("State error: {:?}", e))?;
-    if current_state == crate::primitives::PackState::Uninitialized {
-        session
-            .display()
-            .status()
-            .error("Not in a modpack directory", "");
-        session
-            .display()
-            .status()
-            .subtle("   Run 'empack init' to set up a modpack project");
-        return Err(anyhow::anyhow!("Not in a modpack directory"));
-    }
-    if current_state == PackState::Configured && !manager.validate_state(PackState::Configured)? {
-        session
-            .display()
-            .status()
-            .error("Project initialization is incomplete", "");
-        session.display().status().subtle(
-            "   Re-run 'empack init --force' to restore empack.yml and pack/ metadata before adding dependencies",
-        );
-        return Err(anyhow::anyhow!("Project initialization is incomplete"));
-    }
+    ensure_configured_project(
+        session,
+        &manager.workdir,
+        current_state,
+        "adding dependencies",
+    )?;
 
     let workdir = manager.workdir.clone();
     let config_manager = session.filesystem().config_manager(workdir.clone());
@@ -2494,27 +2551,12 @@ async fn handle_remove(session: &dyn Session, mods: Vec<String>, deps: bool) -> 
     let manager = session.state()?;
 
     let current_state = manager.discover_state()?;
-    if current_state == PackState::Uninitialized {
-        session
-            .display()
-            .status()
-            .error("Not in a modpack directory", "");
-        session
-            .display()
-            .status()
-            .subtle("   Run 'empack init' to set up a modpack project");
-        return Err(anyhow::anyhow!("Not in a modpack directory"));
-    }
-    if current_state == PackState::Configured && !manager.validate_state(PackState::Configured)? {
-        session
-            .display()
-            .status()
-            .error("Project initialization is incomplete", "");
-        session.display().status().subtle(
-            "   Re-run 'empack init --force' to restore empack.yml and pack/ metadata before removing dependencies",
-        );
-        return Err(anyhow::anyhow!("Project initialization is incomplete"));
-    }
+    ensure_configured_project(
+        session,
+        &manager.workdir,
+        current_state,
+        "removing dependencies",
+    )?;
 
     session
         .display()
@@ -2780,27 +2822,7 @@ async fn handle_build(session: &dyn Session, args: &BuildArgs) -> Result<()> {
 
     // Verify we're in a configured state
     let current_state = manager.discover_state()?;
-    if current_state == PackState::Uninitialized {
-        session
-            .display()
-            .status()
-            .error("Not in a modpack directory", "");
-        session
-            .display()
-            .status()
-            .subtle("   Run 'empack init' to set up a modpack project");
-        return Err(anyhow::anyhow!("Not in a modpack directory"));
-    }
-    if current_state == PackState::Configured && !manager.validate_state(PackState::Configured)? {
-        session
-            .display()
-            .status()
-            .error("Project initialization is incomplete", "");
-        session.display().status().subtle(
-            "   Re-run 'empack init --force' to restore empack.yml and pack/ metadata before building",
-        );
-        return Err(anyhow::anyhow!("Project initialization is incomplete"));
-    }
+    ensure_configured_project(session, &manager.workdir, current_state, "building")?;
 
     debug_assert!(
         !args.continue_build || args.targets.is_empty(),
@@ -3345,27 +3367,7 @@ async fn handle_sync(session: &dyn Session) -> Result<()> {
 
     // Verify we're in a configured state
     let current_state = manager.discover_state()?;
-    if current_state == PackState::Uninitialized {
-        session
-            .display()
-            .status()
-            .error("Not in a modpack directory", "");
-        session
-            .display()
-            .status()
-            .subtle("   Run 'empack init' to set up a modpack project");
-        return Err(anyhow::anyhow!("Not in a modpack directory"));
-    }
-    if current_state == PackState::Configured && !manager.validate_state(PackState::Configured)? {
-        session
-            .display()
-            .status()
-            .error("Project initialization is incomplete", "");
-        session.display().status().subtle(
-            "   Re-run 'empack init --force' to restore empack.yml and pack/ metadata before synchronizing",
-        );
-        return Err(anyhow::anyhow!("Project initialization is incomplete"));
-    }
+    ensure_configured_project(session, &manager.workdir, current_state, "synchronizing")?;
 
     let workdir = manager.workdir.clone();
     let config_manager = session.filesystem().config_manager(workdir.clone());

--- a/crates/empack-lib/src/application/commands.test.rs
+++ b/crates/empack-lib/src/application/commands.test.rs
@@ -4942,6 +4942,30 @@ mod handle_clean_tests {
     }
 
     #[tokio::test]
+    async fn it_recovers_interrupted_state_by_removing_marker() {
+        let workdir = mock_root().join("interrupted-clean-recovery");
+        let session = MockCommandSession::new().with_filesystem(
+            MockFileSystemProvider::new()
+                .with_current_dir(workdir.clone())
+                .with_configured_project(workdir.clone())
+                .with_file(
+                    workdir.join(".empack-state"),
+                    "building".to_string(),
+                ),
+        );
+
+        let result = handle_clean(&session, vec!["builds".to_string()]).await;
+
+        assert!(result.is_ok(), "clean should recover interrupted state: {result:?}");
+        assert!(
+            !session.filesystem().exists(&workdir.join(".empack-state")),
+            "clean should remove the interruption marker"
+        );
+        assert!(session.filesystem().exists(&workdir.join("empack.yml")));
+        assert!(session.filesystem().exists(&workdir.join("pack").join("pack.toml")));
+    }
+
+    #[tokio::test]
     async fn it_is_safe_to_clean_builds_twice() {
         let workdir = mock_root().join("configured-clean-twice");
         let session = MockCommandSession::new().with_filesystem(

--- a/crates/empack-lib/src/application/commands.test.rs
+++ b/crates/empack-lib/src/application/commands.test.rs
@@ -504,6 +504,26 @@ mod handle_init_tests {
     }
 
     #[tokio::test]
+    async fn it_refuses_partial_existing_project_without_force() {
+        let workdir = mock_root().join("partial-existing-project");
+        let session = MockCommandSession::new().with_filesystem(
+            MockFileSystemProvider::new()
+                .with_current_dir(workdir.clone())
+                .with_file(
+                    workdir.join("empack.yml"),
+                    "empack:\n  name: partial\n".to_string(),
+                ),
+        );
+
+        let result = handle_init(&session, &InitArgs::default()).await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("incomplete empack project metadata"));
+        assert!(session.filesystem().exists(&workdir.join("empack.yml")));
+    }
+
+    #[tokio::test]
     async fn it_overwrites_existing_with_force() {
         let workdir = mock_root().join("force-pack");
         let session = configured_session(&workdir)
@@ -540,6 +560,48 @@ mod handle_init_tests {
     }
 
     #[tokio::test]
+    async fn it_force_reinitializes_partial_projects() {
+        let workdir = mock_root().join("force-partial-pack");
+        let session = MockCommandSession::new()
+            .with_filesystem(
+                MockFileSystemProvider::new()
+                    .with_current_dir(workdir.clone())
+                    .with_file(
+                        workdir.join("empack.yml"),
+                        "empack:\n  name: stale\n".to_string(),
+                    )
+                    .with_file(
+                        workdir.join(".empack-build-continue.json"),
+                        "{}".to_string(),
+                    )
+                    .with_file(workdir.join("notes.txt"), "keep me".to_string()),
+            )
+            .with_interactive(MockInteractiveProvider::new().with_yes_mode(true));
+
+        let result = handle_init(
+            &session,
+            &InitArgs {
+                force: true,
+                modloader: Some("fabric".to_string()),
+                mc_version: Some("1.21.1".to_string()),
+                author: Some("Overwrite Author".to_string()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(session.filesystem().exists(&workdir.join("empack.yml")));
+        assert!(session.filesystem().exists(&workdir.join("pack").join("pack.toml")));
+        assert!(
+            !session
+                .filesystem()
+                .exists(&workdir.join(".empack-build-continue.json"))
+        );
+        assert!(session.filesystem().exists(&workdir.join("notes.txt")));
+    }
+
+    #[tokio::test]
     async fn it_force_reinitializes_built_projects_from_a_clean_state() {
         let workdir = mock_root().join("force-built-pack");
         let session = MockCommandSession::new()
@@ -565,6 +627,41 @@ mod handle_init_tests {
         assert!(result.is_ok());
         assert!(!session.filesystem().exists(&workdir.join("dist").join("test-pack.mrpack")));
         assert!(session.filesystem().exists(&workdir.join("pack").join("pack.toml")));
+    }
+
+    #[tokio::test]
+    async fn it_force_reinitializes_built_projects_without_deleting_non_project_files() {
+        let workdir = mock_root().join("force-built-pack-preserve");
+        let session = MockCommandSession::new()
+            .with_filesystem(
+                MockFileSystemProvider::new()
+                    .with_current_dir(workdir.clone())
+                    .with_built_project(workdir.clone())
+                    .with_file(workdir.join("templates").join("keep.txt"), "keep".to_string())
+                    .with_file(workdir.join("README.md"), "notes".to_string()),
+            )
+            .with_interactive(MockInteractiveProvider::new().with_yes_mode(true));
+
+        let result = handle_init(
+            &session,
+            &InitArgs {
+                force: true,
+                modloader: Some("fabric".to_string()),
+                mc_version: Some("1.21.1".to_string()),
+                author: Some("Overwrite Author".to_string()),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(session.filesystem().exists(&workdir.join("empack.yml")));
+        assert!(session.filesystem().exists(&workdir.join("pack").join("pack.toml")));
+        assert!(!session.filesystem().exists(&workdir.join("dist").join("test-pack.mrpack")));
+        assert!(!session.filesystem().exists(&workdir.join("dist").join("test-pack.zip")));
+        assert!(session.filesystem().is_directory(&workdir.join("dist")));
+        assert!(session.filesystem().exists(&workdir.join("templates").join("keep.txt")));
+        assert!(session.filesystem().exists(&workdir.join("README.md")));
     }
 
     #[tokio::test]
@@ -1066,6 +1163,37 @@ mod handle_init_from_source_tests {
             err_msg.contains("cannot detect source type") || err_msg.contains("Unrecognized"),
             "unexpected error for remote source: {err_msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn it_refuses_partial_existing_project_without_force() {
+        let base_dir = mock_root().join("init-from-source-partial");
+        let target_dir = base_dir.join("target-pack");
+        let archive = create_mrpack(MR_MANIFEST_JSON);
+        let session = MockCommandSession::new().with_filesystem(
+            MockFileSystemProvider::new()
+                .with_current_dir(base_dir)
+                .with_file(
+                    target_dir.join("empack.yml"),
+                    "empack:\n  name: partial\n".to_string(),
+                ),
+        );
+
+        let result = handle_init_from_source(
+            &session,
+            &archive.path().to_string_lossy(),
+            Some("target-pack".to_string()),
+            false,
+            None,
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("incomplete empack project metadata"));
+        assert!(session.filesystem().exists(&target_dir.join("empack.yml")));
     }
 
     const CF_MANIFEST_JSON: &str = r#"{
@@ -2422,6 +2550,39 @@ mod handle_add_tests {
     }
 
     #[tokio::test]
+    async fn it_rejects_partial_project_layout() {
+        let workdir = mock_root().join("add-partial-project");
+        let session = MockCommandSession::new().with_filesystem(
+            MockFileSystemProvider::new()
+                .with_current_dir(workdir.clone())
+                .with_file(
+                    workdir.join("empack.yml"),
+                    "empack:\n  name: partial\n".to_string(),
+                ),
+        );
+
+        let result = handle_add(
+            &session,
+            vec!["test-mod".to_string()],
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Project initialization is incomplete")
+        );
+        assert!(session.process_provider.get_calls().is_empty());
+    }
+
+    #[tokio::test]
     async fn it_treats_modrinth_id_as_search_query_without_platform_flag() {
         // After removing Modrinth ID auto-detection, "AANobbMI" without --platform
         // is treated as a search query, not a direct ID lookup.
@@ -2924,6 +3085,29 @@ mod handle_remove_tests {
     }
 
     #[tokio::test]
+    async fn it_rejects_pack_metadata_only_partial_project_state() {
+        let workdir = mock_root().join("incomplete-pack-only-project");
+        let session = MockCommandSession::new().with_filesystem(
+            MockFileSystemProvider::new()
+                .with_current_dir(workdir.clone())
+                .with_file(
+                    workdir.join("pack").join("pack.toml"),
+                    "name = \"partial\"\n".to_string(),
+                ),
+        );
+
+        let result = handle_remove(&session, vec!["sodium".to_string()], false).await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Project initialization is incomplete")
+        );
+    }
+
+    #[tokio::test]
     async fn it_skips_side_effects_in_dry_run() {
         let workdir = mock_root().join("configured-project");
         let mut session = configured_session(&workdir);
@@ -3307,6 +3491,30 @@ fabric = "0.16.0"
     }
 
     #[tokio::test]
+    async fn it_rejects_partial_project_layout() {
+        let workdir = mock_root().join("sync-partial-project");
+        let session = MockCommandSession::new().with_filesystem(
+            MockFileSystemProvider::new()
+                .with_current_dir(workdir.clone())
+                .with_file(
+                    workdir.join("pack").join("pack.toml"),
+                    "name = \"partial\"\n".to_string(),
+                ),
+        );
+
+        let result = handle_sync(&session).await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Project initialization is incomplete")
+        );
+        assert!(session.process_provider.get_calls().is_empty());
+    }
+
+    #[tokio::test]
     async fn it_returns_error_when_all_planning_resolutions_fail() {
         // Deps with empty project_id force the resolver path, which returns errors
         let workdir = mock_root().join("all-fail-sync");
@@ -3631,6 +3839,37 @@ mod handle_build_tests {
         let result = handle_build(&session, &BuildArgs { targets: vec!["mrpack".to_string()], ..Default::default() }).await;
 
         assert!(result.is_err(), "handle_build must return Err for incomplete project state");
+        assert!(session.process_provider.get_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn it_rejects_pack_metadata_only_project_state() {
+        let workdir = mock_root().join("incomplete-pack-metadata-project");
+        let session = MockCommandSession::new().with_filesystem(
+            MockFileSystemProvider::new()
+                .with_current_dir(workdir.clone())
+                .with_file(
+                    workdir.join("pack").join("pack.toml"),
+                    "name = \"incomplete\"\n".to_string(),
+                ),
+        );
+
+        let result = handle_build(
+            &session,
+            &BuildArgs {
+                targets: vec!["mrpack".to_string()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        assert!(result.is_err(), "handle_build must return Err for pack-only project state");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Project initialization is incomplete")
+        );
         assert!(session.process_provider.get_calls().is_empty());
     }
 
@@ -4700,6 +4939,29 @@ mod handle_clean_tests {
         let result = handle_clean(&session, vec!["builds".to_string()]).await;
 
         assert!(result.is_ok(), "clean should succeed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn it_is_safe_to_clean_builds_twice() {
+        let workdir = mock_root().join("configured-clean-twice");
+        let session = MockCommandSession::new().with_filesystem(
+            MockFileSystemProvider::new()
+                .with_current_dir(workdir.clone())
+                .with_configured_project(workdir.clone())
+                .with_file(
+                    workdir.join("dist").join("leftover.txt"),
+                    "leftover".to_string(),
+                ),
+        );
+
+        let first = handle_clean(&session, vec!["builds".to_string()]).await;
+        let second = handle_clean(&session, vec!["builds".to_string()]).await;
+
+        assert!(first.is_ok(), "first clean should succeed: {first:?}");
+        assert!(second.is_ok(), "second clean should be a no-op success: {second:?}");
+        assert!(session.filesystem().exists(&workdir.join("empack.yml")));
+        assert!(session.filesystem().exists(&workdir.join("pack").join("pack.toml")));
+        assert!(!session.filesystem().is_directory(&workdir.join("dist")));
     }
 }
 

--- a/crates/empack-lib/src/empack/state.rs
+++ b/crates/empack-lib/src/empack/state.rs
@@ -23,6 +23,23 @@ pub fn artifact_root(workdir: &Path) -> PathBuf {
     workdir.join("dist")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProjectLayoutProbe {
+    pub has_empack_yml: bool,
+    pub has_pack_metadata: bool,
+    pub has_build_artifacts: bool,
+}
+
+impl ProjectLayoutProbe {
+    pub(crate) fn is_configured(self) -> bool {
+        self.has_empack_yml && self.has_pack_metadata
+    }
+
+    pub(crate) fn is_partial_configuration(self) -> bool {
+        self.has_empack_yml ^ self.has_pack_metadata
+    }
+}
+
 fn has_config_file<P: crate::application::session::FileSystemProvider + ?Sized>(
     provider: &P,
     workdir: &Path,
@@ -46,13 +63,15 @@ fn has_canonical_build_artifacts<P: crate::application::session::FileSystemProvi
     provider.is_directory(&dist_dir) && provider.has_build_artifacts(&dist_dir).unwrap_or(false)
 }
 
-fn is_progressive_init_state<P: crate::application::session::FileSystemProvider + ?Sized>(
+pub(crate) fn probe_project_layout<P: crate::application::session::FileSystemProvider + ?Sized>(
     provider: &P,
     workdir: &Path,
-) -> bool {
-    has_config_file(provider, workdir)
-        && !has_pack_metadata(provider, workdir)
-        && !has_canonical_build_artifacts(provider, workdir)
+) -> ProjectLayoutProbe {
+    ProjectLayoutProbe {
+        has_empack_yml: has_config_file(provider, workdir),
+        has_pack_metadata: has_pack_metadata(provider, workdir),
+        has_build_artifacts: has_canonical_build_artifacts(provider, workdir),
+    }
 }
 
 fn validate_state_layout<P: crate::application::session::FileSystemProvider + ?Sized>(
@@ -60,15 +79,11 @@ fn validate_state_layout<P: crate::application::session::FileSystemProvider + ?S
     workdir: &Path,
     expected: &PackState,
 ) -> bool {
+    let layout = probe_project_layout(provider, workdir);
     match expected {
         PackState::Uninitialized => true,
-        PackState::Configured | PackState::Building => {
-            has_config_file(provider, workdir) && has_pack_metadata(provider, workdir)
-        }
-        PackState::Built => {
-            validate_state_layout(provider, workdir, &PackState::Configured)
-                && has_canonical_build_artifacts(provider, workdir)
-        }
+        PackState::Configured | PackState::Building => layout.is_configured(),
+        PackState::Built => layout.is_configured() && layout.has_build_artifacts,
         PackState::Cleaning => provider.is_directory(&artifact_root(workdir)),
         PackState::Interrupted { was } => {
             let mut inner = was.as_ref();
@@ -112,18 +127,15 @@ pub fn discover_state<P: crate::application::session::FileSystemProvider + ?Size
         });
     }
 
-    let empack_yml = workdir.join("empack.yml");
-    let pack_toml = workdir.join("pack").join("pack.toml");
-    let dist_dir = artifact_root(workdir);
+    let layout = probe_project_layout(provider, workdir);
 
     // Check for built state first (most advanced)
-    if provider.is_directory(&dist_dir) && provider.has_build_artifacts(&dist_dir).unwrap_or(false)
-    {
+    if layout.has_build_artifacts {
         return Ok(PackState::Built);
     }
 
-    // Check for configured state via direct exists() calls
-    if provider.exists(&empack_yml) || provider.exists(&pack_toml) {
+    // Configured requires both empack.yml and pack/pack.toml.
+    if layout.is_configured() {
         return Ok(PackState::Configured);
     }
 
@@ -135,9 +147,8 @@ pub fn discover_state<P: crate::application::session::FileSystemProvider + ?Size
 /// Use for tests, UI queries ("can I show a build button?"), and advisory checks.
 pub fn can_transition(from: &PackState, kind: TransitionKind) -> bool {
     match (from, kind) {
-        // Initialize: from Uninitialized always, from Configured needs layout (handled by _with_layout)
+        // Initialize: only from Uninitialized
         (PackState::Uninitialized, TransitionKind::Initialize) => true,
-        (PackState::Configured, TransitionKind::Initialize) => true,
 
         // RefreshIndex: must be Configured, or recovering from interrupted build
         (PackState::Configured, TransitionKind::RefreshIndex) => true,
@@ -180,12 +191,11 @@ pub fn can_transition_with_layout(
     match (from, kind) {
         // Initialize from Uninitialized is always valid (fresh init, no layout to check)
         (PackState::Uninitialized, TransitionKind::Initialize) => true,
-        // Progressive re-init from Configured needs layout validation
-        (_, TransitionKind::Initialize) => layout_ok(from),
         (_, TransitionKind::RefreshIndex) => layout_ok(from),
         (_, TransitionKind::Build) => layout_ok(from),
         // Clean transitions skip layout validation
         (_, TransitionKind::Clean) => true,
+        _ => false,
     }
 }
 
@@ -313,9 +323,7 @@ pub async fn execute_transition<P: crate::application::session::FileSystemProvid
 
     match transition {
         StateTransition::Initialize(config) => {
-            // Progressive init needs a layout check beyond the whitelist:
-            // only allow re-init when no pack metadata or build artifacts exist yet.
-            let layout_ok = |_state: &PackState| is_progressive_init_state(provider, workdir);
+            let layout_ok = |_state: &PackState| true;
             if !can_transition_with_layout(&current, TransitionKind::Initialize, &layout_ok) {
                 return Err(StateError::InvalidTransition {
                     from: current,
@@ -383,28 +391,21 @@ pub async fn execute_transition<P: crate::application::session::FileSystemProvid
                     no_warnings(PackState::Configured)
                 }
                 PackState::Configured => {
-                    clean_configuration(provider, workdir)?;
+                    clean_build_artifacts(provider, workdir)?;
                     remove_state_marker(provider, workdir)?;
+                    no_warnings(PackState::Configured)
+                }
+                PackState::Uninitialized => {
+                    clean_build_artifacts(provider, workdir)?;
                     no_warnings(PackState::Uninitialized)
                 }
-                PackState::Uninitialized => no_warnings(PackState::Uninitialized),
                 PackState::Interrupted { .. } => {
-                    // Recovery: remove the marker and clean from the underlying state
+                    // Clean recovery is intentionally non-destructive. It clears transient
+                    // state and then re-discovers whether the project is still configured.
                     remove_state_marker(provider, workdir)?;
-                    // After removing the marker, re-discover the actual filesystem state
+                    clean_build_artifacts(provider, workdir)?;
                     let recovered = discover_state(provider, workdir)?;
-                    match recovered {
-                        PackState::Built => {
-                            clean_build_artifacts(provider, workdir)?;
-                            no_warnings(PackState::Configured)
-                        }
-                        PackState::Configured => {
-                            clean_configuration(provider, workdir)?;
-                            no_warnings(PackState::Uninitialized)
-                        }
-                        PackState::Uninitialized => no_warnings(PackState::Uninitialized),
-                        _ => no_warnings(recovered),
-                    }
+                    no_warnings(recovered)
                 }
                 PackState::Building | PackState::Cleaning => {
                     unreachable!("can_transition rejects Building/Cleaning for Clean")
@@ -429,7 +430,7 @@ pub fn execute_initialize<P: crate::application::session::FileSystemProvider + ?
 ) -> Result<PackState, StateError> {
     // Create basic directory structure
     create_initial_structure(provider, workdir).inspect_err(|_| {
-        let _ = clean_configuration(provider, workdir);
+        let _ = reset_project_configuration_for_init(provider, workdir);
     })?;
 
     // Generate empack.yml via config.rs using session provider (only if it doesn't exist)
@@ -439,13 +440,13 @@ pub fn execute_initialize<P: crate::application::session::FileSystemProvider + ?
         let default_yml = config_manager
             .generate_default_empack_yml()
             .inspect_err(|_| {
-                let _ = clean_configuration(provider, workdir);
+                let _ = reset_project_configuration_for_init(provider, workdir);
             })?;
 
         provider
             .write_file(&empack_yml, &default_yml)
             .inspect_err(|_| {
-                clean_configuration(provider, workdir).ok(); // Cleanup on failure
+                reset_project_configuration_for_init(provider, workdir).ok(); // Cleanup on failure
             })
             .context("Failed to write empack.yml")?;
     }
@@ -462,7 +463,7 @@ pub fn execute_initialize<P: crate::application::session::FileSystemProvider + ?
             loader_version,
         )
         .inspect_err(|_| {
-            let _ = clean_configuration(provider, workdir);
+            let _ = reset_project_configuration_for_init(provider, workdir);
         })?;
 
     Ok(PackState::Configured)
@@ -537,8 +538,10 @@ pub fn clean_build_artifacts<P: crate::application::session::FileSystemProvider 
     Ok(())
 }
 
-/// Clean configuration files (pure function)
-pub fn clean_configuration<P: crate::application::session::FileSystemProvider + ?Sized>(
+/// Reset core project configuration for an init/rollback flow (pure function)
+pub fn reset_project_configuration_for_init<
+    P: crate::application::session::FileSystemProvider + ?Sized,
+>(
     provider: &P,
     workdir: &Path,
 ) -> Result<(), StateError> {
@@ -557,6 +560,23 @@ pub fn clean_configuration<P: crate::application::session::FileSystemProvider + 
     }
 
     Ok(())
+}
+
+pub(crate) fn reset_project_for_init<
+    P: crate::application::session::FileSystemProvider + ?Sized,
+>(
+    provider: &P,
+    workdir: &Path,
+) -> Result<(), StateError> {
+    let marker_path = workdir.join(STATE_MARKER_FILE);
+    if provider.exists(&marker_path) {
+        provider
+            .remove_file(&marker_path)
+            .context("Failed to remove state marker file")?;
+    }
+
+    clean_build_artifacts(provider, workdir)?;
+    reset_project_configuration_for_init(provider, workdir)
 }
 
 /// Filesystem state machine for modpack development

--- a/crates/empack-lib/src/empack/state.test.rs
+++ b/crates/empack-lib/src/empack/state.test.rs
@@ -233,6 +233,15 @@ fn create_progressive_init_test() -> (MockStateProvider, PathBuf) {
     (mock_provider, workdir)
 }
 
+fn create_pack_metadata_only_test() -> (MockStateProvider, PathBuf) {
+    let (mock_provider, workdir) = create_uninitialized_test();
+
+    mock_provider.add_directory(workdir.join("pack"));
+    mock_provider.add_file(workdir.join("pack").join("pack.toml"));
+
+    (mock_provider, workdir)
+}
+
 fn successful_process_output() -> ProcessOutput {
     ProcessOutput {
         stdout: String::new(),
@@ -339,12 +348,12 @@ async fn test_clean_transitions() {
         .unwrap();
     assert_eq!(result.state, PackState::Configured);
 
-    // Clean back to uninitialized
+    // Cleaning again is idempotent and preserves configuration
     let result = manager
         .execute_transition(&process, &packwiz, StateTransition::Clean)
         .await
         .unwrap();
-    assert_eq!(result.state, PackState::Uninitialized);
+    assert_eq!(result.state, PackState::Configured);
 }
 
 #[tokio::test]
@@ -392,7 +401,7 @@ fn test_state_validation() {
     let manager = PackStateManager::new(workdir, &provider);
     assert!(manager.validate_state(PackState::Built).unwrap());
 
-    // Test progressive init state is not treated as fully configured
+    // Test empack.yml-only state is not treated as fully configured
     let (provider, workdir) = create_progressive_init_test();
     let manager = PackStateManager::new(workdir, &provider);
     assert!(!manager.validate_state(PackState::Configured).unwrap());
@@ -424,6 +433,16 @@ fn test_pure_discover_state_function() {
     let (provider, workdir) = create_configured_test();
     let state = discover_state(&provider, &workdir).unwrap();
     assert_eq!(state, PackState::Configured);
+
+    // Test empack.yml-only partial state
+    let (provider, workdir) = create_progressive_init_test();
+    let state = discover_state(&provider, &workdir).unwrap();
+    assert_eq!(state, PackState::Uninitialized);
+
+    // Test pack.toml-only partial state
+    let (provider, workdir) = create_pack_metadata_only_test();
+    let state = discover_state(&provider, &workdir).unwrap();
+    assert_eq!(state, PackState::Uninitialized);
 
     // Test built state
     let (provider, workdir) = create_built_test();
@@ -501,7 +520,8 @@ async fn test_pure_execute_transition_function() {
     .unwrap();
     assert_eq!(result.state, PackState::Configured);
 
-    // Test initialize transition for progressive-init state after empack.yml exists
+    // Pure state discovery treats partial layouts as Uninitialized. Command handlers are
+    // responsible for surfacing them as incomplete projects before reaching this transition.
     let (provider, workdir) = create_progressive_init_test();
     let result = execute_transition(
         &provider,
@@ -517,9 +537,9 @@ async fn test_pure_execute_transition_function() {
             loader_version: "0.14.21",
         }),
     )
-    .await
-    .unwrap();
-    assert_eq!(result.state, PackState::Configured);
+    .await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().state, PackState::Configured);
 
     // Test build transition
     let workdir = mock_root().join("configured-project");
@@ -555,7 +575,7 @@ async fn test_pure_execute_transition_function() {
     let result = execute_transition(&provider, &process, &packwiz, &workdir, StateTransition::Clean)
         .await
         .unwrap();
-    assert_eq!(result.state, PackState::Uninitialized);
+    assert_eq!(result.state, PackState::Configured);
 }
 
 #[tokio::test]
@@ -567,6 +587,70 @@ async fn test_refresh_transition_rejects_progressive_init_state() {
     let result = execute_transition(&provider, &process, &packwiz, &workdir, StateTransition::RefreshIndex).await;
 
     assert!(matches!(result, Err(StateError::InvalidTransition { .. })));
+}
+
+#[test]
+fn test_discover_state_requires_both_empack_yml_and_pack_toml_for_configured() {
+    let (provider, workdir) = create_configured_test();
+    let state = discover_state(&provider, &workdir).unwrap();
+    assert_eq!(state, PackState::Configured);
+}
+
+#[test]
+fn test_discover_state_treats_empack_yml_only_as_uninitialized() {
+    let (provider, workdir) = create_progressive_init_test();
+    let state = discover_state(&provider, &workdir).unwrap();
+    assert_eq!(state, PackState::Uninitialized);
+}
+
+#[test]
+fn test_discover_state_treats_pack_toml_only_as_uninitialized() {
+    let (provider, workdir) = create_pack_metadata_only_test();
+    let state = discover_state(&provider, &workdir).unwrap();
+    assert_eq!(state, PackState::Uninitialized);
+}
+
+#[tokio::test]
+async fn test_clean_from_configured_preserves_project_configuration() {
+    let (provider, workdir) = create_configured_test();
+    let process = crate::application::session_mocks::MockProcessProvider::new();
+    let packwiz = mock_packwiz_for_test();
+
+    let result = execute_transition(
+        &provider,
+        &process,
+        &packwiz,
+        &workdir,
+        StateTransition::Clean,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.state, PackState::Configured);
+    assert!(provider.exists(&workdir.join("empack.yml")));
+    assert!(provider.exists(&workdir.join("pack").join("pack.toml")));
+}
+
+#[tokio::test]
+async fn test_clean_from_uninitialized_removes_stray_dist_only() {
+    let (provider, workdir) = create_uninitialized_test();
+    let process = crate::application::session_mocks::MockProcessProvider::new();
+    let packwiz = mock_packwiz_for_test();
+    provider.add_directory(artifact_root(&workdir));
+    provider.add_file(artifact_root(&workdir).join("leftover.txt"));
+
+    let result = execute_transition(
+        &provider,
+        &process,
+        &packwiz,
+        &workdir,
+        StateTransition::Clean,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.state, PackState::Uninitialized);
+    assert!(!provider.directories.borrow().contains(&artifact_root(&workdir)));
 }
 
 #[tokio::test]
@@ -699,9 +783,9 @@ fn test_pure_clean_functions() {
             .contains(&workdir.join("dist"))
     );
 
-    // Test clean_configuration
+    // Test reset_project_configuration_for_init
     let (provider, workdir) = create_configured_test();
-    let result = clean_configuration(&provider, &workdir);
+    let result = reset_project_configuration_for_init(&provider, &workdir);
     assert!(result.is_ok());
     assert!(
         !provider
@@ -973,9 +1057,9 @@ async fn test_clean_removes_marker_on_interrupted_state() {
     .await
     .unwrap();
 
-    // After cleaning an interrupted-building, the underlying state was Configured
-    // so cleaning from Configured -> Uninitialized
-    assert_eq!(result.state, PackState::Uninitialized);
+    assert_eq!(result.state, PackState::Configured);
+    assert!(provider.exists(&workdir.join("empack.yml")));
+    assert!(provider.exists(&workdir.join("pack").join("pack.toml")));
 
     // Marker file should be removed
     assert!(

--- a/crates/empack-lib/src/primitives/empack.rs
+++ b/crates/empack-lib/src/primitives/empack.rs
@@ -95,9 +95,9 @@ impl std::str::FromStr for BuildTarget {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum PackState {
-    /// No empack.yml or pack/ directory exists
+    /// No valid empack modpack layout is present
     Uninitialized,
-    /// empack.yml exists, pack/ may be initialized
+    /// Both empack.yml and pack/pack.toml exist
     Configured,
     /// Built artifacts exist in the project-local dist/ artifact root
     Built,
@@ -132,7 +132,7 @@ pub enum TransitionKind {
     RefreshIndex,
     /// Configured/Built -> Built (full build)
     Build,
-    /// Built -> Configured or Configured -> Uninitialized
+    /// Non-destructive build-artifact cleanup; idempotent when nothing is built
     Clean,
 }
 

--- a/crates/empack-tests/tests/init_workflows.rs
+++ b/crates/empack-tests/tests/init_workflows.rs
@@ -218,8 +218,8 @@ async fn test_init_existing_project_error() -> Result<()> {
     );
     let err_msg = result.unwrap_err().to_string();
     assert!(
-        err_msg.contains("already contains a modpack project"),
-        "Error should mention existing project: {}",
+        err_msg.contains("incomplete empack project metadata"),
+        "Error should mention incomplete project metadata: {}",
         err_msg
     );
 

--- a/docs/specs/cli-surface.md
+++ b/docs/specs/cli-surface.md
@@ -192,3 +192,5 @@ empack clean [TARGET]...
 | `all` | Clean both builds and cache |
 
 If no clean target is provided, the command treats the request as `builds`.
+
+`clean` never removes project metadata such as `empack.yml` or `pack/`.

--- a/docs/specs/state-machine.md
+++ b/docs/specs/state-machine.md
@@ -2,7 +2,7 @@
 spec: state-machine
 status: draft
 created: 2026-04-04
-updated: 2026-04-08
+updated: 2026-04-10
 depends: [overview, types]
 ---
 
@@ -18,10 +18,12 @@ Discovery order matters:
 | --- | --- | --- |
 | 1 | `.empack-state` exists and contains `building` or `cleaning` | `Interrupted { was: Building | Cleaning }` |
 | 2 | `dist/` contains canonical build artifacts | `Built` |
-| 3 | `empack.yml` exists or `pack/pack.toml` exists | `Configured` |
+| 3 | `empack.yml` exists and `pack/pack.toml` exists | `Configured` |
 | 4 | none of the above | `Uninitialized` |
 
-`validate_state()` is stricter than `discover_state()`. It checks the expected layout for the requested state, not just a minimal presence signal.
+Directories with only one core metadata artifact are treated as `Uninitialized` for state discovery. Command handlers may still surface those layouts as incomplete initialization rather than as generic non-project directories.
+
+`validate_state()` checks the expected layout for the requested state.
 
 ## Layout Rules
 
@@ -42,13 +44,13 @@ Configured -> Configured        RefreshIndex
 Configured -> Built             Build
 Built -> Built                  Build
 Built -> Configured             Clean
-Configured -> Uninitialized     Clean
+Configured -> Configured        Clean
 Interrupted(Building) -> Built  Build
 Interrupted(Building) -> Configured  RefreshIndex or Clean
 Interrupted(Cleaning) -> Configured or Uninitialized  Clean recovery
 ```
 
-`Initialize` from `Configured` is allowed only for progressive re-initialization. That path requires `empack.yml` without full pack metadata or build artifacts.
+`Initialize` is the pure `Uninitialized -> Configured` transition. `init --force` performs an explicit command-layer reset of project core files before calling the state transition.
 
 ## Marker Transitions
 
@@ -74,6 +76,7 @@ Current behavior:
 - `run_packwiz_init()` populates `pack/pack.toml` and related packwiz files.
 - Failure during initialization cleans partial configuration where possible.
 - Template scaffolding is not part of the pure state transition. Command handlers install templates after the transition succeeds.
+- `init --force` resets `empack.yml`, `pack/`, markers, and `dist/` explicitly before initialization. That reset is not part of the `Clean` state transition.
 
 ### Refresh Index
 
@@ -89,15 +92,18 @@ Successful build returns `Built`.
 
 ### Clean
 
-`Clean` has two current behaviors:
+`Clean` is a non-destructive, idempotent build-artifact cleanup transition.
 
 | Starting state | Behavior | Result |
 | --- | --- | --- |
 | `Built` | Remove build artifacts from `dist/` | `Configured` |
-| `Configured` | Remove `empack.yml` and `pack/` | `Uninitialized` |
+| `Configured` | Remove build artifacts from `dist/` if present | `Configured` |
+| `Uninitialized` | Remove stray build artifacts from `dist/` if present | `Uninitialized` |
 
 Additional clean rules:
 
 - `Clean` from `Uninitialized` is idempotent.
-- `Clean` from `Interrupted { .. }` removes the marker first, then re-discovers the underlying filesystem state and cleans accordingly.
+- `Clean` from `Interrupted { .. }` removes the marker first, removes `dist/` if present, then re-discovers the underlying filesystem state.
+- `Clean` never removes `empack.yml`.
+- `Clean` never removes `pack/`.
 - `clean --cache` is a command-layer operation. It is not part of the `PackState` transition model.


### PR DESCRIPTION
## Summary
- require both empack.yml and pack/pack.toml for the Configured state
- make the Clean transition non-destructive and keep user-facing clean limited to build/cache cleanup
- move force init reset to an explicit internal reset path and update partial-layout diagnostics/specs

## Test plan
- cargo test -p empack-lib --features test-utils handle_init_tests --lib
- cargo test -p empack-lib --features test-utils handle_init_from_source_tests --lib
- cargo test -p empack-lib --features test-utils handle_add_tests --lib
- cargo test -p empack-lib --features test-utils handle_remove_tests --lib
- cargo test -p empack-lib --features test-utils handle_sync_tests --lib
- cargo test -p empack-lib --features test-utils handle_build_tests --lib
- cargo test -p empack-lib --features test-utils handle_clean_tests --lib
- cargo test -p empack-lib --features test-utils empack::state::tests --lib